### PR TITLE
Correct block size

### DIFF
--- a/idea.go
+++ b/idea.go
@@ -43,7 +43,7 @@ func NewCipher(key []byte) (cipher.Block, error) {
 	return cipher, nil
 }
 
-func (c *ideaCipher) BlockSize() int          { return 16 }
+func (c *ideaCipher) BlockSize() int          { return 8 }
 func (c *ideaCipher) Encrypt(dst, src []byte) { crypt(src, dst, c.ek[:]) }
 func (c *ideaCipher) Decrypt(dst, src []byte) { crypt(src, dst, c.dk[:]) }
 


### PR DESCRIPTION
Although key size is 16, BlockSize() is actually 8, since `crypt` operates on 8 byte chunks. The correct value is needed when using this with `cipher.NewCBCDecrypter`
